### PR TITLE
OTP Null Reference Exception fix

### DIFF
--- a/Lassie/Program.cs
+++ b/Lassie/Program.cs
@@ -195,7 +195,8 @@ namespace Lassie
                     Console.Write("OTP: ");
                     string otp = Console.ReadLine();
                     client.DefaultRequestHeaders.Add("X-GitHub-OTP", otp);
-                    response = await client.PostAsync("authorizations", stringContent);
+                    var stringContent2 = new StringContent(contentString);
+                    response = await client.PostAsync("authorizations", stringContent2);
                 }
 
                 string json;


### PR DESCRIPTION
Apparently StringContent gets disposed after the first HttpClient.PostAsync() call. Made a second copy to get rid of exception during OTP entry.
